### PR TITLE
Add i18n support for template labels (English default)

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "sidebar_title": "Table of Contents",
+  "settings_title": "Settings"
+}

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -1,0 +1,4 @@
+{
+  "sidebar_title": "文档目录",
+  "settings_title": "设置"
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,22 +9,26 @@ pub struct Args {
     /// Path to the markdown documentation directory
     #[arg(short, long, value_name = "DIR")]
     pub docs_dir: PathBuf,
-    
+
     /// Port to serve the web interface on
     #[arg(short, long, default_value = "3000", value_name = "PORT")]
     pub port: u16,
-    
+
     /// Host to bind the server to
     #[arg(long, default_value = "127.0.0.1", value_name = "HOST")]
     pub host: String,
-    
+
     /// Open browser automatically after starting the server
     #[arg(short, long)]
     pub open: bool,
-    
+
     /// Enable verbose logging
     #[arg(short, long)]
     pub verbose: bool,
+
+    /// UI language for server-rendered labels (e.g. en, zh, de)
+    #[arg(long, default_value = "en", value_name = "LANG")]
+    pub lang: String,
 }
 
 impl Args {
@@ -36,14 +40,11 @@ impl Args {
                 self.docs_dir.display()
             );
         }
-        
+
         if !self.docs_dir.is_dir() {
-            anyhow::bail!(
-                "Path is not a directory: {}",
-                self.docs_dir.display()
-            );
+            anyhow::bail!("Path is not a directory: {}", self.docs_dir.display());
         }
-        
+
         // Check if port is available
         if self.port < 1024 && !is_privileged() {
             anyhow::bail!(
@@ -51,18 +52,33 @@ impl Args {
                 self.port
             );
         }
-        
+
         Ok(())
     }
-    
+
     /// Get the server URL
     pub fn server_url(&self) -> String {
         format!("http://{}:{}", self.host, self.port)
     }
-    
+
     /// Get the bind address
     pub fn bind_address(&self) -> String {
         format!("{}:{}", self.host, self.port)
+    }
+
+    /// Get normalized language code for template rendering
+    pub fn language(&self) -> String {
+        let normalized = self.lang.trim().to_lowercase().replace('_', "-");
+        if normalized.is_empty() {
+            return "en".to_string();
+        }
+
+        normalized
+            .split('-')
+            .next()
+            .filter(|part| !part.is_empty())
+            .unwrap_or("en")
+            .to_string()
     }
 }
 
@@ -72,14 +88,14 @@ fn is_privileged() -> bool {
     {
         unsafe { libc::geteuid() == 0 }
     }
-    
+
     #[cfg(windows)]
     {
         // On Windows, we'll just return true for simplicity
         // In a real implementation, you'd check for admin privileges
         true
     }
-    
+
     #[cfg(not(any(unix, windows)))]
     {
         false

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,21 +11,21 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() -> anyhow::Result<()> {
     // Parse command line arguments
     let args = cli::Args::parse();
-    
+
     // Initialize logging
     init_logging(args.verbose);
-    
+
     // Print banner
     print_banner();
-    
+
     // Validate arguments
     if let Err(e) = args.validate() {
         error!("参数验证失败: {}", e);
         std::process::exit(1);
     }
-    
+
     info!("正在扫描文档目录: {}", args.docs_dir.display());
-    
+
     // Build document tree
     let doc_tree = match filesystem::DocumentTree::new(&args.docs_dir) {
         Ok(tree) => {
@@ -36,11 +36,11 @@ async fn main() -> anyhow::Result<()> {
                 stats.total_dirs,
                 format_bytes(stats.total_size)
             );
-            
+
             if stats.total_files == 0 {
                 warn!("未找到任何 Markdown 文件，请检查目录是否包含 .md 文件");
             }
-            
+
             tree
         }
         Err(e) => {
@@ -48,11 +48,11 @@ async fn main() -> anyhow::Result<()> {
             std::process::exit(1);
         }
     };
-    
+
     // Create router
     let docs_path = args.docs_dir.display().to_string().replace('\\', "/");
-    let app = server::create_router(doc_tree, docs_path);
-    
+    let app = server::create_router(doc_tree, docs_path, args.language());
+
     // Start server
     let bind_address = args.bind_address();
     let listener = match tokio::net::TcpListener::bind(&bind_address).await {
@@ -65,14 +65,14 @@ async fn main() -> anyhow::Result<()> {
             std::process::exit(1);
         }
     };
-    
+
     let server_url = args.server_url();
-    
+
     info!("🚀 Litho Book 服务器启动成功!");
     info!("📖 访问地址: {}", server_url);
     info!("📁 文档目录: {}", args.docs_dir.display());
     info!("⏹️  按 Ctrl+C 停止服务器");
-    
+
     // Auto-open browser
     if args.open {
         info!("正在打开浏览器...");
@@ -81,13 +81,13 @@ async fn main() -> anyhow::Result<()> {
             info!("请手动访问: {}", server_url);
         }
     }
-    
+
     // Start server
     if let Err(e) = axum::serve(listener, app).await {
         error!("服务器运行错误: {}", e);
         std::process::exit(1);
     }
-    
+
     Ok(())
 }
 
@@ -98,7 +98,7 @@ fn init_logging(verbose: bool) {
     } else {
         tracing_subscriber::filter::LevelFilter::INFO
     };
-    
+
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
@@ -106,7 +106,7 @@ fn init_logging(verbose: bool) {
                 .with_thread_ids(false)
                 .with_thread_names(false)
                 .with_file(false)
-                .with_line_number(false)
+                .with_line_number(false),
         )
         .with(filter)
         .init();
@@ -129,56 +129,50 @@ fn open_browser(url: &str) -> anyhow::Result<()> {
             .args(["/c", "start", "", url])
             .spawn()?;
     }
-    
+
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
-            .arg(url)
-            .spawn()?;
+        std::process::Command::new("open").arg(url).spawn()?;
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         // Try different browsers in order of preference
         let browsers = ["xdg-open", "firefox", "chromium", "google-chrome"];
-        
+
         for browser in &browsers {
-            if std::process::Command::new(browser)
-                .arg(url)
-                .spawn()
-                .is_ok()
-            {
+            if std::process::Command::new(browser).arg(url).spawn().is_ok() {
                 return Ok(());
             }
         }
-        
+
         anyhow::bail!("No suitable browser found");
     }
-    
+
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     {
         anyhow::bail!("Automatic browser opening not supported on this platform");
     }
-    
+
     Ok(())
 }
 
 /// Format bytes into human-readable format
 fn format_bytes(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];
-    
+
     if bytes == 0 {
         return "0 B".to_string();
     }
-    
+
     let mut size = bytes as f64;
     let mut unit_index = 0;
-    
+
     while size >= 1024.0 && unit_index < UNITS.len() - 1 {
         size /= 1024.0;
         unit_index += 1;
     }
-    
+
     if unit_index == 0 {
         format!("{} {}", bytes, UNITS[unit_index])
     } else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,10 @@ use axum::{
 };
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
+use std::fs;
+use std::path::Path;
 use std::time::Duration;
 use tower_http::{cors::CorsLayer, services::ServeDir};
 use tracing::{debug, error, info};
@@ -18,6 +21,7 @@ use crate::filesystem::{DocumentTree, SearchResult};
 pub struct AppState {
     pub doc_tree: DocumentTree,
     pub docs_path: String,
+    pub lang: String,
 }
 
 #[derive(Deserialize)]
@@ -102,10 +106,11 @@ pub struct StreamEvent {
 }
 
 /// Create the main application router
-pub fn create_router(doc_tree: DocumentTree, docs_path: String) -> Router {
+pub fn create_router(doc_tree: DocumentTree, docs_path: String, lang: String) -> Router {
     let state = AppState {
         doc_tree,
         docs_path,
+        lang,
     };
 
     Router::new()
@@ -130,7 +135,7 @@ async fn index_handler(State(state): State<AppState>) -> Result<Html<String>, St
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let html = generate_index_html(&tree_json, &state.docs_path);
+    let html = generate_index_html(&tree_json, &state.docs_path, &state.lang);
     Ok(Html(html))
 }
 
@@ -391,20 +396,17 @@ async fn call_openai_stream_api(
 
     let response = client
         .post("https://open.bigmodel.cn/api/paas/v4/chat/completions")
-        .header(
-            "Authorization",
-            {
-                use std::env;
-                use tracing::log::error;
+        .header("Authorization", {
+            use std::env;
+            use tracing::log::error;
 
-                let llm_key = env::var("LITHO_BOOK_LLM_KEY").unwrap_or_else(|_| {
-                    error!("LITHO_BOOK_LLM_KEY environment variable not set, using empty string");
-                    String::new()
-                });
+            let llm_key = env::var("LITHO_BOOK_LLM_KEY").unwrap_or_else(|_| {
+                error!("LITHO_BOOK_LLM_KEY environment variable not set, using empty string");
+                String::new()
+            });
 
-                format!("Bearer {}", llm_key)
-            },
-        )
+            format!("Bearer {}", llm_key)
+        })
         .header("Content-Type", "application/json")
         .json(&request_body)
         .send()
@@ -546,12 +548,60 @@ fn format_bytes(bytes: u64) -> String {
 }
 
 /// Generate the main HTML page
-fn generate_index_html(tree_json: &str, docs_path: &str) -> String {
+fn generate_index_html(tree_json: &str, docs_path: &str, lang: &str) -> String {
+    let labels = load_labels(lang);
+
     // Read the template file
     let template_content = include_str!("../templates/index.html.tpl");
 
     // Replace the placeholders with actual data
-    template_content
+    let mut html = template_content
         .replace("{{ tree_json|safe }}", tree_json)
-        .replace("{{ docs_path }}", docs_path)
+        .replace("{{ docs_path }}", docs_path);
+
+    // Generic i18n placeholder replacement:
+    // {{ i18n.some_key }} -> labels["some_key"]
+    for (key, value) in labels {
+        let placeholder = format!("{{{{ i18n.{} }}}}", key);
+        html = html.replace(&placeholder, &value);
+    }
+
+    html
 }
+
+fn load_labels(lang: &str) -> HashMap<String, String> {
+    let i18n_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("i18n");
+    let en_path = i18n_dir.join("en.json");
+    let mut labels = load_i18n_map(&en_path)
+        .or_else(|| {
+            serde_json::from_str::<HashMap<String, String>>(include_str!("../i18n/en.json")).ok()
+        })
+        .unwrap_or_default();
+
+    let normalized_lang = normalize_lang(lang);
+    if normalized_lang != "en" {
+        let lang_path = i18n_dir.join(format!("{}.json", normalized_lang));
+        if let Some(lang_labels) = load_i18n_map(&lang_path) {
+            // English keys remain the fallback for missing translations.
+            labels.extend(lang_labels);
+        }
+    }
+
+    labels
+}
+
+fn normalize_lang(lang: &str) -> String {
+    let normalized = lang.trim().to_lowercase().replace('_', "-");
+    normalized
+        .split('-')
+        .next()
+        .filter(|part| !part.is_empty())
+        .unwrap_or("en")
+        .to_string()
+}
+
+fn load_i18n_map(path: &Path) -> Option<HashMap<String, String>> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<HashMap<String, String>>(&content).ok()
+}
+

--- a/templates/index.html.tpl
+++ b/templates/index.html.tpl
@@ -1857,7 +1857,7 @@
                 <button
                     class="settings-btn"
                     onclick="openSettings()"
-                    title="设置"
+                    title="{{ i18n.settings_title }}"
                 >
                     <svg
                         width="20"
@@ -1898,7 +1898,7 @@
                                 d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1 1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
                             ></path>
                         </svg>
-                        设置
+                        {{ i18n.settings_title }}
                     </div>
                     <button class="settings-close" onclick="closeSettings()">
                         <svg
@@ -2023,7 +2023,7 @@
         <div class="container">
             <div class="sidebar" id="sidebar">
                 <div class="sidebar-header">
-                    <div class="sidebar-title">文档目录</div>
+                    <div class="sidebar-title">{{ i18n.sidebar_title }}</div>
                     <button class="toggle-btn" onclick="toggleSidebar()">
                         <svg
                             width="16"


### PR DESCRIPTION
This PR is a first step toward resolving #23.
It introduces:
- a CLI language option (`--lang`)
- file-based i18n catalogs (`i18n/en.json`, `i18n/zh.json`)
- server-side template placeholder resolution (`{{ i18n.<key> }}`), demonstrated with:
  - `sidebar_title`
  - `settings_title`
The implementation uses English as fallback when a key is missing in the selected language file.
If this approach is accepted, I can follow up with a second PR that migrates the remaining UI labels (EN/CN) and optionally adds DE (`i18n/de.json`).
